### PR TITLE
Only load needed ActiveSupport extensions

### DIFF
--- a/lib/happening.rb
+++ b/lib/happening.rb
@@ -5,7 +5,10 @@ require 'logger'
 
 require 'active_support'
 unless {}.respond_to?(:assert_valid_keys)
-  require 'active_support/core_ext'
+  require 'active_support/core_ext/hash/keys.rb'
+end
+unless {}.respond_to?(:blank?)
+  require 'active_support/core_ext/object/blank.rb'
 end
 
 require File.dirname(__FILE__) + '/happening/log'


### PR DESCRIPTION
I'm using happening in an small app that doesn't have any other dependencies on ActiveSupport. To load `activesupport/core_ext` in the latest ActiveSupport means including the whole of I18n and possibly other gems, which seemed like a lot of code. 

This change only includes the ActiveSupport extensions that are actually used in happening.
