### PR TITLE
This allows the get call to return the response so I can stream the data.

### DIFF
--- a/lib/happening/s3/request.rb
+++ b/lib/happening/s3/request.rb
@@ -33,7 +33,7 @@ module Happening
 
         @response.errback { error_callback }
         @response.callback { success_callback }
-        nil
+        @response
       end
       
       def http_class

--- a/test/s3/request_test.rb
+++ b/test/s3/request_test.rb
@@ -43,6 +43,13 @@ class ItemTest < Test::Unit::TestCase
         Happening::S3::Request.new(:get, 'https://www.example.com').execute
       end
       
+      should "return the response" do
+        request = mock(:get => @response_stub)
+        EventMachine::MockHttpRequest.expects(:new).with('https://www.example.com').returns(request)
+        resp = Happening::S3::Request.new(:get, 'https://www.example.com').execute
+        assert_equal resp, @response_stub
+      end
+      
       should "pass the given headers and options" do
         request = mock('em-http-request')
         request.expects(:get).with(:timeout => 10, :head => {'a' => 'b'}, :body => nil,  :ssl => {:verify_peer => false, :cert_chain_file => nil}).returns(@response_stub)


### PR DESCRIPTION
Here's my example usage:

``` ruby
    item = Happening::S3::Item.new( bucket...
    item.get(:on_error => on_error, :on_success => on_success ).stream do |chunk|
      @crypto.decrypt(chunk) do |data|
        env.stream_send(data)
      end          
    end
```

Using this in Goliath to decrypt a file from S3.

Thanks
Carl
