### PR TITLE
Making it easier to use EM's callback chain

### DIFF
--- a/lib/happening/s3/request.rb
+++ b/lib/happening/s3/request.rb
@@ -31,9 +31,15 @@ module Happening
         Happening::Log.debug "Request: #{http_method.to_s.upcase} #{url}"
         @response = http_class.new(url).send(http_method, :timeout => options[:timeout], :head => options[:headers], :body => options[:data], :ssl => options[:ssl])
 
-        @response.errback { error_callback }
-        @response.callback { success_callback }
-        nil
+        @response.errback { 
+          error_callback 
+          @response.set_deferred_status :failed
+        }
+        @response.callback { 
+          success_callback 
+          @response.set_deferred_status :succeeded
+        }
+        @response
       end
       
       def http_class


### PR DESCRIPTION
I've made 2 small changes.

First, the deferrable object is passed back after execute is called.  Second, I've set the deferred state appropriately after each internal callback.  Together these changes allow someone to create a much richer callback chain than is currently possible with on_success and on_error.

Here's an example of what I'm doing with it

```
s = Sssnake.new
s.on_message do | file |
  bname = File.basename(local)
  item = Happening::S3::Item.new(
    'a.bucket', 
    "some/path/#{bname}",
    :aws_access_key_id => Settings[:aws][:aws_access_key_id], 
    :aws_secret_access_key => Settings[:aws][:aws_secret_key]
  )
  df = item.put(File.read(local))

  df
end
```

In this example, the file upload is wrapped in a "message received" event from a queue.  Is this something that fits how this library is being used?
