### PR TITLE
Added support for other S3 compatible APIs like Walrus and Cumulus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "http://rubygems.org"
-gem "em-http-request"
+
+gem "em-http-request", "~> 1.0.2"
 
 group :development do
   gem "shoulda", ">= 0"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Alternatives like RightAws block during the HTTP calls thus blocking the Nanite-
 For now it only supports GET, PUT and DELETE operations on S3 items. The PUT operations support S3 ACLs/permissions.
 Happening will handle redirects and retries on errors by default.
 
+Happening also supports other S3 compatible APIs, like Eucalyptus Walrus and Nimbus Cumulus. See instructions below
+for more details.
+
 Installation
 ============
 
@@ -176,6 +179,28 @@ Or even on the request:
     item.get(:ssl => {:cert_chain_file => '/etc/ca-bundle.crt'})
     
 The SSL options are directly passed to EventMachine, see the [EventMachine documentation](http://eventmachine.rubyforge.org/EventMachine/Connection.html#M000296) for more information on the SSL support.
+
+
+Walrus
+=============
+
+Happening also supports interacting with Walrus storage from the Eucalyptus cloud. The only difference is in the Item
+initialization. Here you should prepend the bucket name with the 'services/Walrus/' string, as this is the base path
+used by the Walrus API and should be signed allong with the bucket name. You should specify the host address and port
+where Walrus listens for incoming requests too.
+
+     Happening::S3::Item.new('services/Walrus/bucket', 'item_id', :server => 'Walrus address', :port => 8773, :protocol => 'http',
+        :aws_access_key_id => 'Walrus ID', :aws_secret_access_key => 'Walrus secret')
+
+
+Cumulus
+=============
+
+Happening also supports interacting with Cumulus storage from the Nimbus cloud. The only difference is in the Item
+initialization, where you should specify the host address and port where Cumulus listens for incoming requests.
+
+     Happening::S3::Item.new('bucket', 'item_id', :server => 'cumulus address', :port => 8888, :protocol => 'http',
+        :aws_access_key_id => 'cumulus ID', :aws_secret_access_key => 'cumulus secret')
 
 
 Credits

--- a/happening.gemspec
+++ b/happening.gemspec
@@ -4,67 +4,67 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{happening}
-  s.version = "0.2.5"
+  s.name = "happening"
+  s.version = "0.2.6"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = [%q{Jonathan Weiss}]
-  s.date = %q{2011-08-23}
-  s.description = %q{An EventMachine based S3 client }
-  s.email = %q{jw@innerewut.de}
+  s.authors = ["Jonathan Weiss"]
+  s.date = "2012-03-13"
+  s.description = "An EventMachine based S3 client "
+  s.email = "jw@innerewut.de"
   s.extra_rdoc_files = [
-    "LICENSE.txt",
-    "README.md"
+      "LICENSE.txt",
+      "README.md"
   ]
   s.files = [
-    "CHANGELOG.md",
-    "Gemfile",
-    "LICENSE.txt",
-    "README.md",
-    "Rakefile",
-    "benchmark/right_aws.rb",
-    "happening.gemspec",
-    "lib/happening.rb",
-    "lib/happening/aws.rb",
-    "lib/happening/log.rb",
-    "lib/happening/s3.rb",
-    "lib/happening/s3/item.rb",
-    "lib/happening/s3/request.rb",
-    "lib/happening/utils.rb",
-    "test/aws_test.rb",
-    "test/s3/item_test.rb",
-    "test/s3/request_test.rb",
-    "test/s3_test.rb",
-    "test/test_helper.rb"
+      "CHANGELOG.md",
+      "Gemfile",
+      "LICENSE.txt",
+      "README.md",
+      "Rakefile",
+      "VERSION",
+      "benchmark/right_aws.rb",
+      "happening.gemspec",
+      "lib/happening.rb",
+      "lib/happening/aws.rb",
+      "lib/happening/log.rb",
+      "lib/happening/s3.rb",
+      "lib/happening/s3/item.rb",
+      "lib/happening/s3/request.rb",
+      "lib/happening/utils.rb",
+      "test/aws_test.rb",
+      "test/s3/item_test.rb",
+      "test/s3/request_test.rb",
+      "test/s3_test.rb",
+      "test/test_helper.rb"
   ]
-  s.homepage = %q{http://github.com/peritor/happening}
-  s.licenses = [%q{BSD}]
-  s.require_paths = [%q{lib}]
-  s.rubygems_version = %q{1.8.7}
-  s.summary = %q{An EventMachine based S3 client}
+  s.homepage = "http://github.com/peritor/happening"
+  s.licenses = ["BSD"]
+  s.require_paths = ["lib"]
+  s.rubygems_version = "1.8.15"
+  s.summary = "An EventMachine based S3 client"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<em-http-request>, [">= 0"])
+      s.add_runtime_dependency(%q<em-http-request>, ["~> 1.0.2"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<mocha>, [">= 0"])
     else
-      s.add_dependency(%q<em-http-request>, [">= 0"])
+      s.add_dependency(%q<em-http-request>, ["~> 1.0.2"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_dependency(%q<mocha>, [">= 0"])
     end
   else
-    s.add_dependency(%q<em-http-request>, [">= 0"])
+    s.add_dependency(%q<em-http-request>, ["~> 1.0.2"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
     s.add_dependency(%q<mocha>, [">= 0"])
   end
 end
-

--- a/lib/happening/s3/item.rb
+++ b/lib/happening/s3/item.rb
@@ -57,6 +57,13 @@ module Happening
         Happening::S3::Request.new(:put, url, {:ssl => options[:ssl]}.update(request_options)).execute
       end
 
+      def store(file_path, request_options = {}, &blk)
+        headers = construct_aws_headers('PUT', request_options.delete(:headers) || {})
+        request_options[:on_success] = blk if blk
+        request_options.update(:headers => headers, :file => file_path)
+        Happening::S3::Request.new(:put, url, {:ssl => options[:ssl]}.update(request_options)).execute
+      end
+
       def delete(request_options = {}, &blk)
         headers = needs_to_sign? ? aws.sign("DELETE", path, {'url' => path}) : {}
         request_options[:on_success] = blk if blk

--- a/lib/happening/s3/item.rb
+++ b/lib/happening/s3/item.rb
@@ -22,7 +22,7 @@ module Happening
           :permissions => 'private',
           :ssl => Happening::S3.ssl_options
         }.update(symbolize_keys(options))
-        assert_valid_keys(options, :timeout, :server, :protocol, :aws_access_key_id, :aws_secret_access_key, :retry_count, :permissions, :ssl)
+        assert_valid_keys(options, :timeout, :server, :port, :protocol, :aws_access_key_id, :aws_secret_access_key, :retry_count, :permissions, :ssl)
         @aws_id = aws_id.to_s
         @bucket = bucket.to_s
       
@@ -58,10 +58,12 @@ module Happening
       end
     
       def url
-        URI::Generic.new(options[:protocol], nil, server, port, nil, path(!dns_bucket?), nil, nil, nil).to_s
+        uri = options[:port] ? path : path(!dns_bucket?)
+        URI::Generic.new(options[:protocol], nil, server, port, nil, uri, nil, nil, nil).to_s
       end
       
       def server
+        return options[:server] if options[:port]
         dns_bucket? ? "#{bucket}.#{options[:server]}" : options[:server]
       end
       
@@ -85,7 +87,7 @@ module Happening
       end
     
       def port
-        (options[:protocol].to_s == 'https') ? 443 : 80
+        options[:port] || (options[:protocol].to_s == 'https' ? 443 : 80)
       end
     
       def validate

--- a/lib/happening/s3/item.rb
+++ b/lib/happening/s3/item.rb
@@ -5,10 +5,10 @@ module Happening
   module S3
     class Item
       include Utils
-    
+
       REQUIRED_FIELDS = [:server]
       VALID_HEADERS = ['Cache-Control', 'Content-Disposition', 'Content-Encoding', 'Content-Length', 'Content-MD5', 'Content-Type', 'Expect', 'Expires']
-    
+
       attr_accessor :bucket, :aws_id, :options
 
       def initialize(bucket, aws_id, options = {})
@@ -25,10 +25,10 @@ module Happening
         assert_valid_keys(options, :timeout, :server, :port, :protocol, :aws_access_key_id, :aws_secret_access_key, :retry_count, :permissions, :ssl)
         @aws_id = aws_id.to_s
         @bucket = bucket.to_s
-      
+
         validate
       end
-    
+
       def head(request_options = {}, &blk)
         headers = needs_to_sign? ? aws.sign("HEAD", path) : {}
         request_options[:on_success] = blk if blk
@@ -42,41 +42,48 @@ module Happening
         request_options.update(:headers => headers)
         Happening::S3::Request.new(:get, url, {:ssl => options[:ssl]}.update(request_options)).execute
       end
-      
+
+      def aget(request_options = {}, &blk)
+        headers = needs_to_sign? ? aws.sign("GET", path) : {}
+        request_options[:on_success] = blk if blk
+        request_options.update(:headers => headers)
+        Happening::S3::Request.new(:aget, url, {:ssl => options[:ssl]}.update(request_options)).execute
+      end
+
       def put(data, request_options = {}, &blk)
         headers = construct_aws_headers('PUT', request_options.delete(:headers) || {})
         request_options[:on_success] = blk if blk
         request_options.update(:headers => headers, :data => data)
         Happening::S3::Request.new(:put, url, {:ssl => options[:ssl]}.update(request_options)).execute
       end
-      
+
       def delete(request_options = {}, &blk)
         headers = needs_to_sign? ? aws.sign("DELETE", path, {'url' => path}) : {}
         request_options[:on_success] = blk if blk
         request_options.update(:headers => headers)
         Happening::S3::Request.new(:delete, url, {:ssl => options[:ssl]}.update(request_options)).execute
       end
-    
+
       def url
         uri = options[:port] ? path : path(!dns_bucket?)
         URI::Generic.new(options[:protocol], nil, server, port, nil, uri, nil, nil, nil).to_s
       end
-      
+
       def server
         return options[:server] if options[:port]
         dns_bucket? ? "#{bucket}.#{options[:server]}" : options[:server]
       end
-      
+
       def path(with_bucket=true)
         with_bucket ? "/#{bucket}/#{CGI::escape(aws_id)}" : "/#{CGI::escape(aws_id)}"
       end
-    
+
     protected
-        
+
       def needs_to_sign?
         present?(options[:aws_access_key_id])
       end
-    
+
       def dns_bucket?
         # http://docs.amazonwebservices.com/AmazonS3/2006-03-01/index.html?BucketRestrictions.html
         return false unless (3..63) === bucket.size
@@ -85,38 +92,38 @@ module Happening
         end
         true
       end
-    
+
       def port
         options[:port] || (options[:protocol].to_s == 'https' ? 443 : 80)
       end
-    
+
       def validate
         raise ArgumentError, "need a bucket name" unless present?(bucket)
         raise ArgumentError, "need a AWS Key" unless present?(aws_id)
-      
+
         REQUIRED_FIELDS.each do |field|
           raise ArgumentError, "need field #{field}" unless present?(options[field])
         end
-      
+
         raise ArgumentError, "unknown protocoll #{options[:protocol]}" unless ['http', 'https'].include?(options[:protocol])
       end
-      
+
       def aws
         @aws ||= Happening::AWS.new(options[:aws_access_key_id], options[:aws_secret_access_key])
       end
-      
+
       def construct_aws_headers(http_method, headers = {})
         unless headers.keys.all?{|header| VALID_HEADERS.include?(header) || header.to_s.match(/\Ax-amz-/) }
-          raise ArgumentError, "invalid headers. All headers must either one of #{VALID_HEADERS} or start with 'x-amz-'" 
+          raise ArgumentError, "invalid headers. All headers must either one of #{VALID_HEADERS} or start with 'x-amz-'"
         end
-        
+
         permissions = options[:permissions] != 'private' ? {'x-amz-acl' => options[:permissions] } : {}
         headers.update(permissions)
         headers.update({'url' => path})
-        
+
         headers = needs_to_sign? ? aws.sign(http_method, path, headers) : headers
       end
-    
+
     end
   end
 end

--- a/lib/happening/s3/request.rb
+++ b/lib/happening/s3/request.rb
@@ -3,7 +3,7 @@ module Happening
     class Request
       include Utils
       
-      VALID_HTTP_METHODS = [:head, :get, :put, :delete]
+      VALID_HTTP_METHODS = [:head, :get, :aget, :put, :delete]
       
       attr_accessor :http_method, :url, :options, :response
       

--- a/lib/happening/s3/request.rb
+++ b/lib/happening/s3/request.rb
@@ -20,7 +20,7 @@ module Happening
             :verify_peer => false
           }
         }.update(options)
-        assert_valid_keys(options, :timeout, :on_success, :on_error, :retry_count, :headers, :data, :ssl)
+        assert_valid_keys(options, :timeout, :on_success, :on_error, :retry_count, :headers, :data, :ssl, :file)
         @http_method = http_method
         @url = url
         
@@ -29,7 +29,7 @@ module Happening
       
       def execute
         Happening::Log.debug "Request: #{http_method.to_s.upcase} #{url}"
-        @response = http_class.new(url).send(http_method, :timeout => options[:timeout], :head => options[:headers], :body => options[:data], :ssl => options[:ssl])
+        @response = http_class.new(url).send(http_method, :timeout => options[:timeout], :head => options[:headers], :body => options[:data], :ssl => options[:ssl], :file => options[:file])
 
         @response.errback { error_callback }
         @response.callback { success_callback }


### PR DESCRIPTION
Hi,

Basically this is done by exposing the :port option and avoid the S3 specific features like the dns buckets when the port is provided. I have this working against my Eucalyptus and Nimbus clouds. I've also added some notes about these features in the README.
